### PR TITLE
feat: ERROR/OK on variant response and displayed in the table

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -242,3 +242,20 @@ body {
   width: auto;
   margin: 0 0.5rem;
 }
+
+.tag {
+  display: inline;
+  padding: 0.3rem 0.8rem;
+  border-radius: 0.3rem;
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: #fff;
+}
+
+.error-tag {
+  background-color: #e95147;
+}
+
+.ok-tag {
+  background-color: #4dc35a;
+}

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -76,32 +76,11 @@ const Table = (props: TableProps) => {
     fv,
   } = props;
 
-  const getBackgroundColor = (index: string, cellId: string) => {
-    const POLYPHEN_PREDICTION = {
-      BENIGN: "benign",
-      POSSIBLY_DAMAGING: "possibly_damaging",
-      PROBABLY_DAMAGING: "probably_damaging",
-    };
-
-    const SIFT_PREDICTION = {
-      DELETERIOUS: "deleterious",
-      TOLERATED: "tolerated",
-    };
-
-    const idx = Number(index);
-    const value =
-      cellId === "polyphenPrediction"
-        ? data[idx].polyphenPrediction!
-        : data[idx].siftPrediction!;
-
-    if (value === POLYPHEN_PREDICTION.POSSIBLY_DAMAGING) return "#ffba5f";
-    else if (
-      value === POLYPHEN_PREDICTION.PROBABLY_DAMAGING ||
-      value === SIFT_PREDICTION.DELETERIOUS
-    )
-      return "#e56565";
-    else if (value === POLYPHEN_PREDICTION.BENIGN || SIFT_PREDICTION.TOLERATED)
-      return "#85cc64";
+  const getTagClassname = (errorRow: boolean, rowHeader: any) => {
+    if (rowHeader === "Status") {
+      return errorRow ? "error-tag tag" : "ok-tag tag";
+    }
+    return "";
   };
 
   const getCellContent = (cell: Cell<VariantData, any>) => {
@@ -244,25 +223,26 @@ const Table = (props: TableProps) => {
         <tbody {...getTableBodyProps()}>
           {page.map((row) => {
             prepareRow(row);
-            let errorRow = row.values.status === "ERROR" ? true : false;
+            const errorRow = row.values.status === "ERROR";
             return (
               <tr {...row.getRowProps()} key={uuidv4()}>
                 {row.cells.map((cell) => {
                   return (
                     <td
                       style={{
-                        backgroundColor:
-                          cell.column.id === "polyphenPrediction" ||
-                          cell.column.id === "siftPrediction"
-                            ? getBackgroundColor(cell.row.id, cell.column.id)
-                            : errorRow
-                            ? "#e56565"
-                            : "#FFF",
+                        backgroundColor: errorRow ? "#fff6e8" : "#FFF",
                       }}
                       {...cell.getCellProps()}
                       key={uuidv4()}
                     >
-                      {getCellContent(cell)}
+                      <p
+                        className={getTagClassname(
+                          errorRow,
+                          cell.column.Header,
+                        )}
+                      >
+                        {getCellContent(cell)}
+                      </p>
                     </td>
                   );
                 })}

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -3,6 +3,7 @@ import {
   useSortBy,
   usePagination,
   useGlobalFilter,
+  Cell,
 } from "react-table";
 import { useExportData } from "react-table-plugins";
 import React, { useMemo } from "react";
@@ -45,6 +46,10 @@ const RESULT_COLUMN_DATA = [
   {
     Header: "Polyphen Prediction",
     accessor: "polyphenPrediction",
+  },
+  {
+    Header: "Status",
+    accessor: "status",
   },
 ];
 
@@ -97,6 +102,12 @@ const Table = (props: TableProps) => {
       return "#e56565";
     else if (value === POLYPHEN_PREDICTION.BENIGN || SIFT_PREDICTION.TOLERATED)
       return "#85cc64";
+  };
+
+  const getCellContent = (cell: Cell<VariantData, any>) => {
+    /*if (!cell.value || cell.value === -1) cell.value = -100;
+    console.log(cell.value);*/
+    return cell.render("Cell");
   };
 
   const callGetPredictions = async (csvData: VariantData[]) => {
@@ -233,6 +244,7 @@ const Table = (props: TableProps) => {
         <tbody {...getTableBodyProps()}>
           {page.map((row) => {
             prepareRow(row);
+            let errorRow = row.values.status === "ERROR" ? true : false;
             return (
               <tr {...row.getRowProps()} key={uuidv4()}>
                 {row.cells.map((cell) => {
@@ -243,12 +255,14 @@ const Table = (props: TableProps) => {
                           cell.column.id === "polyphenPrediction" ||
                           cell.column.id === "siftPrediction"
                             ? getBackgroundColor(cell.row.id, cell.column.id)
+                            : errorRow
+                            ? "#e56565"
                             : "#FFF",
                       }}
                       {...cell.getCellProps()}
                       key={uuidv4()}
                     >
-                      {cell.render("Cell")}
+                      {getCellContent(cell)}
                     </td>
                   );
                 })}

--- a/src/utils/helpers/parseData.ts
+++ b/src/utils/helpers/parseData.ts
@@ -7,8 +7,8 @@ export const parseData = (variantData: VariantData[]) => {
   variantData.map((data) => {
     if (data.status === "ERROR") {
       errors.push(data);
-      data.sift = -1;
-      data.polyphen = -1;
+      data.sift = "";
+      data.polyphen = "";
     }
     // To show all the data (irrespective of errorneous variants)
     parsedData.push(data);

--- a/src/utils/helpers/parseData.ts
+++ b/src/utils/helpers/parseData.ts
@@ -5,9 +5,13 @@ export const parseData = (variantData: VariantData[]) => {
   const errors: VariantData[] = [];
 
   variantData.map((data) => {
-    if (data.sift === -1 && data.polyphen == -1) {
+    if (data.status === "ERROR") {
       errors.push(data);
-    } else parsedData.push(data);
+      data.sift = -1;
+      data.polyphen = -1;
+    }
+    // To show all the data (irrespective of errorneous variants)
+    parsedData.push(data);
   });
 
   return { parsedData, errors };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -93,9 +93,9 @@ export type VariantData = {
   nextprotPosition: number;
   originalAminoAcid: string;
   variantAminoAcid: string;
-  sift?: number;
+  sift?: number | string;
   siftPrediction?: string;
-  polyphen?: number;
+  polyphen?: number | string;
   polyphenPrediction?: string;
   enspPosition?: number;
   status?: string;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -98,6 +98,7 @@ export type VariantData = {
   polyphen?: number;
   polyphenPrediction?: string;
   enspPosition?: number;
+  status?: string;
 };
 
 export type FeatureData = MetaData & {


### PR DESCRIPTION
-- API now responds with  all the original/variant inputs with status : [OK, ERROR].
-- In the result table, all the variants should be displayed, if the status : ERROR highlight the row appropriately.